### PR TITLE
Added Dueling DQN

### DIFF
--- a/vdueling_dqn.py
+++ b/vdueling_dqn.py
@@ -1,4 +1,4 @@
-# Reference: https://www.cs.toronto.edu/~vmnih/docs/dqn.pdf
+# Reference: https://arxiv.org/pdf/1511.06581.pdf
 
 import argparse
 import os

--- a/vdueling_dqn.py
+++ b/vdueling_dqn.py
@@ -126,12 +126,12 @@ if __name__ == "__main__":
         wandb.init(
             project=args.wandb_project_name,
             entity=args.wandb_entity,
-            sync_tensorboard=True,
             config=vars(args),
             name=run_name,
             monitor_gym=True,
             save_code=True,
         )
+        wandb.tensorboard.patch(save=False)
 
     writer = SummaryWriter(f"runs/{run_name}")
     writer.add_text(

--- a/vdueling_dqn.py
+++ b/vdueling_dqn.py
@@ -34,7 +34,7 @@ def parse_args():
         help="if toggled, cuda will be enabled by default")
     parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
         help="if toggled, this experiment will be tracked with Weights and Biases")
-    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+    parser.add_argument("--wandb-project-name", type=str, default="vectorized-value-methods",
         help="the wandb's project name")
     parser.add_argument("--wandb-entity", type=str, default=None,
         help="the entity (team) of wandb's project")

--- a/vdueling_dqn.py
+++ b/vdueling_dqn.py
@@ -105,9 +105,9 @@ class QNetwork(nn.Module):
         self.advantage = nn.Linear(64, envs.single_action_space.n)
 
     def forward(self, x):
-        features = self.network(x)
-        value = self.value(features)
-        advantage = self.advantage(features)
+        hidden = self.network(x)
+        value = self.value(hidden)
+        advantage = self.advantage(hidden)
         avg_advantage = torch.mean(advantage, dim=1, keepdim=True)
         return value + advantage - avg_advantage
 

--- a/vdueling_dqn.py
+++ b/vdueling_dqn.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
-        
+
         wandb.init(
             project=args.wandb_project_name,
             entity=args.wandb_entity,

--- a/vdueling_dqn.py
+++ b/vdueling_dqn.py
@@ -1,0 +1,256 @@
+# Reference: https://www.cs.toronto.edu/~vmnih/docs/dqn.pdf
+
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
+
+import gym
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.tensorboard import SummaryWriter
+
+
+def parse_args():
+    # Common arguments
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--gym-id", type=str, default="CartPole-v1",
+        help="the id of the gym environment")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--total-timesteps", type=int, default=300000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, `torch.backends.cudnn.deterministic=False`")
+    parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, cuda will be enabled by default")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
+
+    # Algorithm specific arguments
+    parser.add_argument("--asyncvec", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to use the async vectorized environments")
+    parser.add_argument("--num-envs", type=int, default=8,
+        help="the number of parallel game environments")
+    parser.add_argument("--num-steps", type=int, default=128,
+        help="the number of steps to run in each environment per policy rollout")
+    parser.add_argument("--num-minibatches", type=int, default=27,
+        help="the number of mini-batches")
+    parser.add_argument("--update-epochs", type=int, default=30,
+        help="the K epochs to update the policy")
+    parser.add_argument("--gamma", type=float, default=0.99,
+        help="the discount factor gamma")
+    parser.add_argument("--target-network-frequency", type=int, default=1000,
+        help="the timesteps it takes to update the target network")
+    parser.add_argument("--max-grad-norm", type=float, default=0.5,
+        help="the maximum norm for the gradient clipping")
+    parser.add_argument("--start-e", type=float, default=1.0,
+        help="the starting epsilon for exploration")
+    parser.add_argument("--end-e", type=float, default=0.05,
+        help="the ending epsilon for exploration")
+    parser.add_argument("--exploration-fraction", type=float, default=0.8,
+        help="the fraction of `total-timesteps` it takes from start-e to go end-e")
+    args = parser.parse_args()
+    args.batch_size = int(args.num_envs * args.num_steps)
+    args.minibatch_size = int(args.batch_size // args.num_minibatches)
+    # fmt: on
+    return args
+
+
+def make_env(gym_id, seed, idx, capture_video, run_name):
+    def thunk():
+        env = gym.make(gym_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
+
+    return thunk
+
+
+def layer_init(layer, std=np.sqrt(2), bias_const=0.0):
+    torch.nn.init.orthogonal_(layer.weight, std)
+    torch.nn.init.constant_(layer.bias, bias_const)
+    return layer
+
+
+class QNetwork(nn.Module):
+    def __init__(self, envs):
+        super(QNetwork, self).__init__()
+        self.network = nn.Sequential(
+            layer_init(nn.Linear(np.array(envs.single_observation_space.shape).prod(), 64)),
+            nn.ReLU(),
+            layer_init(nn.Linear(64, 64)),
+            nn.ReLU(),
+        )
+        self.value = nn.Linear(64, 1)
+        self.advantage = nn.Linear(64, envs.single_action_space.n)
+
+    def forward(self, x):
+        features = self.network(x)
+        value = self.value(features)
+        advantage = self.advantage(features)
+        avg_advantage = torch.mean(advantage, dim=1, keepdim=True)
+        return value + advantage - avg_advantage
+
+
+def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
+    slope = (end_e - start_e) / duration
+    return max(slope * t + start_e, end_e)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
+        wandb.tensorboard.patch(root_logdir='runs/')
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
+
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = args.torch_deterministic
+
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
+
+    # env setup
+    VecEnv = gym.vector.AsyncVectorEnv if args.asyncvec else gym.vector.SyncVectorEnv
+    envs = VecEnv([make_env(args.gym_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)])
+    assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
+
+    # ALGO LOGIC: initialize agent here:
+    q_network = QNetwork(envs).to(device)
+    target_network = QNetwork(envs).to(device)
+    target_network.load_state_dict(q_network.state_dict())
+    optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate)
+    loss_fn = nn.MSELoss()
+
+    # ALGO Logic: Storage setup
+    obs = torch.zeros((args.num_steps, args.num_envs) + envs.single_observation_space.shape).to(device)
+    actions = torch.zeros((args.num_steps, args.num_envs) + envs.single_action_space.shape).to(device)
+    rewards = torch.zeros((args.num_steps, args.num_envs)).to(device)
+    dones = torch.zeros((args.num_steps, args.num_envs)).to(device)
+
+    # TRY NOT TO MODIFY: start the game
+    global_step = 0
+    start_time = time.time()
+    next_obs = torch.Tensor(envs.reset()).to(device)
+    next_done = torch.zeros(args.num_envs).to(device)
+    num_updates = args.total_timesteps // args.batch_size
+    num_gradient_updates = 0
+
+    for update in range(1, num_updates + 1):
+        # ROLLOUTS
+        epsilon = linear_schedule(
+            args.start_e,
+            args.end_e,
+            args.exploration_fraction * args.total_timesteps,
+            global_step,
+        )
+        writer.add_scalar("charts/epsilon", epsilon, global_step)
+        for step in range(0, args.num_steps):
+            global_step += 1 * args.num_envs
+            obs[step] = next_obs
+            dones[step] = next_done
+
+            # ALGO LOGIC: action logic
+            with torch.no_grad():
+                logits = q_network.forward(next_obs)
+                action = torch.argmax(logits, dim=1)
+                random_action = torch.randint(0, envs.single_action_space.n, (envs.num_envs,), device=device)
+                random_action_flag = torch.rand(envs.num_envs, device=device) > epsilon
+                action = torch.where(random_action_flag, action, random_action)
+            actions[step] = action
+
+            # TRY NOT TO MODIFY: execute the game and log data.
+            next_obs, reward, done, info = envs.step(action.cpu().numpy())
+            rewards[step] = torch.tensor(reward).to(device).view(-1)
+            next_obs, next_done = (
+                torch.Tensor(next_obs).to(device),
+                torch.Tensor(done).to(device),
+            )
+
+            for item in info:
+                if "episode" in item.keys():
+                    print(f"global_step={global_step}, episodic_return={item['episode']['r']}")
+                    writer.add_scalar("charts/episodic_return", item["episode"]["r"], global_step)
+                    writer.add_scalar("charts/episodic_length", item["episode"]["l"], global_step)
+                    break
+
+        # TRAINING
+        b_obs = obs.reshape((-1,) + envs.single_observation_space.shape)
+        b_actions = actions.reshape((-1, 1)).long()
+        b_rewards = rewards.reshape((-1,))
+        b_dones = dones.reshape((-1,))
+
+        # next_obs index manipulation
+        b_next_obs = torch.zeros_like(obs).to(device)
+        b_next_obs[:-1] = obs[1:]
+        b_next_obs[-1] = next_obs
+        b_next_obs = b_next_obs.reshape((-1,) + envs.single_observation_space.shape)
+        b_inds = np.arange(args.batch_size)
+        for epoch in range(args.update_epochs):
+            np.random.shuffle(b_inds)
+            for start in range(0, args.batch_size, args.minibatch_size):
+                num_gradient_updates += 1
+                end = start + args.minibatch_size
+                mb_inds = b_inds[start:end]
+
+                with torch.no_grad():
+                    target_max, _ = target_network.forward(b_next_obs[mb_inds]).max(dim=1)
+                    td_target = b_rewards[mb_inds] + args.gamma * target_max * (1 - b_dones[mb_inds])
+                old_val = q_network.forward(b_obs[mb_inds]).gather(1, b_actions[mb_inds]).squeeze()
+                loss = loss_fn(td_target, old_val)
+
+                writer.add_scalar("losses/td_loss", loss, global_step)
+
+                # optimize the model
+                optimizer.zero_grad()
+                loss.backward()
+                nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)
+                optimizer.step()
+
+                # update the target network
+                if num_gradient_updates % args.target_network_frequency == 0:
+                    target_network.load_state_dict(q_network.state_dict())
+
+        writer.add_scalar("losses/q_values", old_val.mean().item(), global_step)
+        print("SPS:", int(global_step / (time.time() - start_time)))
+        writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
+
+    envs.close()
+    writer.close()

--- a/vdueling_dqn.py
+++ b/vdueling_dqn.py
@@ -36,7 +36,7 @@ def parse_args():
         help="if toggled, this experiment will be tracked with Weights and Biases")
     parser.add_argument("--wandb-project-name", type=str, default="vectorized-value-methods",
         help="the wandb's project name")
-    parser.add_argument("--wandb-entity", type=str, default=None,
+    parser.add_argument("--wandb-entity", type=str, default="vwxyzjn",
         help="the entity (team) of wandb's project")
     parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
         help="weather to capture videos of the agent performances (check out `videos` folder)")

--- a/vdueling_dqn.py
+++ b/vdueling_dqn.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
         import wandb
-        wandb.tensorboard.patch(root_logdir='runs/')
+        
         wandb.init(
             project=args.wandb_project_name,
             entity=args.wandb_entity,

--- a/vdueling_dqn_atari.py
+++ b/vdueling_dqn_atari.py
@@ -1,0 +1,277 @@
+# Reference: https://arxiv.org/pdf/1511.06581.pdf
+
+import argparse
+import os
+import random
+import time
+from distutils.util import strtobool
+
+import gym
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.tensorboard import SummaryWriter
+
+from stable_baselines3.common.atari_wrappers import (  # isort:skip
+    ClipRewardEnv,
+    EpisodicLifeEnv,
+    FireResetEnv,
+    MaxAndSkipEnv,
+    NoopResetEnv,
+)
+
+
+def parse_args():
+    # Common arguments
+    # fmt: off
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--exp-name", type=str, default=os.path.basename(__file__).rstrip(".py"),
+        help="the name of this experiment")
+    parser.add_argument("--gym-id", type=str, default="BreakoutNoFrameskip-v4",
+        help="the id of the gym environment")
+    parser.add_argument("--learning-rate", type=float, default=2.5e-4,
+        help="the learning rate of the optimizer")
+    parser.add_argument("--seed", type=int, default=1,
+        help="seed of the experiment")
+    parser.add_argument("--total-timesteps", type=int, default=10000000,
+        help="total timesteps of the experiments")
+    parser.add_argument("--torch-deterministic", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, `torch.backends.cudnn.deterministic=False`")
+    parser.add_argument("--cuda", type=lambda x: bool(strtobool(x)), default=True, nargs="?", const=True,
+        help="if toggled, cuda will be enabled by default")
+    parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+        help="the wandb's project name")
+    parser.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
+    parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to capture videos of the agent performances (check out `videos` folder)")
+
+    # Algorithm specific arguments
+    parser.add_argument("--asyncvec", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="weather to use the async vectorized environments")
+    parser.add_argument("--num-envs", type=int, default=8,
+        help="the number of parallel game environments")
+    parser.add_argument("--num-steps", type=int, default=128,
+        help="the number of steps to run in each environment per policy rollout")
+    parser.add_argument("--num-minibatches", type=int, default=4,
+        help="the number of mini-batches")
+    parser.add_argument("--update-epochs", type=int, default=8,
+        help="the K epochs to update the policy")
+    parser.add_argument("--gamma", type=float, default=0.99,
+        help="the discount factor gamma")
+    parser.add_argument("--target-network-frequency", type=int, default=1000,
+        help="the timesteps it takes to update the target network")
+    parser.add_argument("--max-grad-norm", type=float, default=0.5,
+        help="the maximum norm for the gradient clipping")
+    parser.add_argument("--start-e", type=float, default=1.0,
+        help="the starting epsilon for exploration")
+    parser.add_argument("--end-e", type=float, default=0.05,
+        help="the ending epsilon for exploration")
+    parser.add_argument("--exploration-fraction", type=float, default=0.1,
+        help="the fraction of `total-timesteps` it takes from start-e to go end-e")
+    args = parser.parse_args()
+    args.batch_size = int(args.num_envs * args.num_steps)
+    args.minibatch_size = int(args.batch_size // args.num_minibatches)
+    # fmt: on
+    return args
+
+
+def make_env(gym_id, seed, idx, capture_video, run_name):
+    def thunk():
+        env = gym.make(gym_id)
+        env = gym.wrappers.RecordEpisodeStatistics(env)
+        if capture_video:
+            if idx == 0:
+                env = gym.wrappers.RecordVideo(env, f"videos/{run_name}")
+        env = NoopResetEnv(env, noop_max=30)
+        env = MaxAndSkipEnv(env, skip=4)
+        env = EpisodicLifeEnv(env)
+        if "FIRE" in env.unwrapped.get_action_meanings():
+            env = FireResetEnv(env)
+        env = ClipRewardEnv(env)
+        env = gym.wrappers.ResizeObservation(env, (84, 84))
+        env = gym.wrappers.GrayScaleObservation(env)
+        env = gym.wrappers.FrameStack(env, 4)
+        env.seed(seed)
+        env.action_space.seed(seed)
+        env.observation_space.seed(seed)
+        return env
+
+    return thunk
+
+
+class QNetwork(nn.Module):
+    def __init__(self, env, frames=4):
+        super(QNetwork, self).__init__()
+        self.network = nn.Sequential(
+            nn.Conv2d(frames, 32, 8, stride=4),
+            nn.ReLU(),
+            nn.Conv2d(32, 64, 4, stride=2),
+            nn.ReLU(),
+            nn.Conv2d(64, 64, 3, stride=1),
+            nn.ReLU(),
+            nn.Flatten()
+        )
+        self.advantage = nn.Sequential(
+            nn.Linear(3136, 512),
+            nn.ReLU(),
+            nn.Linear(512, env.single_action_space.n),
+        )
+        self.value = nn.Sequential(
+            nn.Linear(3136, 512),
+            nn.ReLU(),
+            nn.Linear(512, 1),
+        )
+
+    def forward(self, x):
+        features = self.network(x / 255.0)
+        value = self.value(features)
+        advantage = self.advantage(features)
+        avg_advantage = torch.mean(advantage, dim=1, keepdim=True)
+        return value + advantage - avg_advantage
+
+
+def linear_schedule(start_e: float, end_e: float, duration: int, t: int):
+    slope = (end_e - start_e) / duration
+    return max(slope * t + start_e, end_e)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    run_name = f"{args.gym_id}__{args.exp_name}__{args.seed}__{int(time.time())}"
+    if args.track:
+        import wandb
+
+        wandb.init(
+            project=args.wandb_project_name,
+            entity=args.wandb_entity,
+            sync_tensorboard=True,
+            config=vars(args),
+            name=run_name,
+            monitor_gym=True,
+            save_code=True,
+        )
+    writer = SummaryWriter(f"runs/{run_name}")
+    writer.add_text(
+        "hyperparameters",
+        "|param|value|\n|-|-|\n%s" % ("\n".join([f"|{key}|{value}|" for key, value in vars(args).items()])),
+    )
+
+    # TRY NOT TO MODIFY: seeding
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = args.torch_deterministic
+
+    device = torch.device("cuda" if torch.cuda.is_available() and args.cuda else "cpu")
+
+    # env setup
+    VecEnv = gym.vector.AsyncVectorEnv if args.asyncvec else gym.vector.SyncVectorEnv
+    envs = VecEnv([make_env(args.gym_id, args.seed + i, i, args.capture_video, run_name) for i in range(args.num_envs)])
+    assert isinstance(envs.single_action_space, gym.spaces.Discrete), "only discrete action space is supported"
+
+    # ALGO LOGIC: initialize agent here:
+    q_network = QNetwork(envs).to(device)
+    target_network = QNetwork(envs).to(device)
+    target_network.load_state_dict(q_network.state_dict())
+    optimizer = optim.Adam(q_network.parameters(), lr=args.learning_rate)
+    loss_fn = nn.MSELoss()
+
+    # ALGO Logic: Storage setup
+    obs = torch.zeros((args.num_steps, args.num_envs) + envs.single_observation_space.shape).to(device)
+    actions = torch.zeros((args.num_steps, args.num_envs) + envs.single_action_space.shape).to(device)
+    rewards = torch.zeros((args.num_steps, args.num_envs)).to(device)
+    dones = torch.zeros((args.num_steps, args.num_envs)).to(device)
+
+    # TRY NOT TO MODIFY: start the game
+    global_step = 0
+    start_time = time.time()
+    next_obs = torch.Tensor(envs.reset()).to(device)
+    next_done = torch.zeros(args.num_envs).to(device)
+    num_updates = args.total_timesteps // args.batch_size
+    num_gradient_updates = 0
+
+    for update in range(1, num_updates + 1):
+        # ROLLOUTS
+        epsilon = linear_schedule(
+            args.start_e,
+            args.end_e,
+            args.exploration_fraction * args.total_timesteps,
+            global_step,
+        )
+        writer.add_scalar("charts/epsilon", epsilon, global_step)
+        for step in range(0, args.num_steps):
+            global_step += 1 * args.num_envs
+            obs[step] = next_obs
+            dones[step] = next_done
+
+            # ALGO LOGIC: action logic
+            with torch.no_grad():
+                logits = q_network.forward(next_obs)
+                action = torch.argmax(logits, dim=1)
+                random_action = torch.randint(0, envs.single_action_space.n, (envs.num_envs,), device=device)
+                random_action_flag = torch.rand(envs.num_envs, device=device) > epsilon
+                action = torch.where(random_action_flag, action, random_action)
+            actions[step] = action
+
+            # TRY NOT TO MODIFY: execute the game and log data.
+            next_obs, reward, done, info = envs.step(action.cpu().numpy())
+            rewards[step] = torch.tensor(reward).to(device).view(-1)
+            next_obs, next_done = (
+                torch.Tensor(next_obs).to(device),
+                torch.Tensor(done).to(device),
+            )
+
+            for item in info:
+                if "episode" in item.keys():
+                    print(f"global_step={global_step}, episodic_return={item['episode']['r']}")
+                    writer.add_scalar("charts/episodic_return", item["episode"]["r"], global_step)
+                    writer.add_scalar("charts/episodic_length", item["episode"]["l"], global_step)
+                    break
+
+        # TRAINING
+        b_obs = obs.reshape((-1,) + envs.single_observation_space.shape)
+        b_actions = actions.reshape((-1, 1)).long()
+        b_rewards = rewards.reshape((-1,))
+        b_dones = dones.reshape((-1,))
+
+        # next_obs index manipulation
+        b_next_obs = torch.zeros_like(obs).to(device)
+        b_next_obs[:-1] = obs[1:]
+        b_next_obs[-1] = next_obs
+        b_next_obs = b_next_obs.reshape((-1,) + envs.single_observation_space.shape)
+        b_inds = np.arange(args.batch_size)
+        for epoch in range(args.update_epochs):
+            np.random.shuffle(b_inds)
+            for start in range(0, args.batch_size, args.minibatch_size):
+                num_gradient_updates += 1
+                end = start + args.minibatch_size
+                mb_inds = b_inds[start:end]
+
+                with torch.no_grad():
+                    target_max, _ = target_network.forward(b_next_obs[mb_inds]).max(dim=1)
+                    td_target = b_rewards[mb_inds] + args.gamma * target_max * (1 - b_dones[mb_inds])
+                old_val = q_network.forward(b_obs[mb_inds]).gather(1, b_actions[mb_inds]).squeeze()
+                loss = loss_fn(td_target, old_val)
+
+                writer.add_scalar("losses/td_loss", loss, global_step)
+
+                # optimize the model
+                optimizer.zero_grad()
+                loss.backward()
+                nn.utils.clip_grad_norm_(list(q_network.parameters()), args.max_grad_norm)
+                optimizer.step()
+
+                # update the target network
+                if num_gradient_updates % args.target_network_frequency == 0:
+                    target_network.load_state_dict(q_network.state_dict())
+
+        writer.add_scalar("losses/q_values", old_val.mean().item(), global_step)
+        print("SPS:", int(global_step / (time.time() - start_time)))
+        writer.add_scalar("charts/SPS", int(global_step / (time.time() - start_time)), global_step)
+
+    envs.close()
+    writer.close()

--- a/vdueling_dqn_atari.py
+++ b/vdueling_dqn_atari.py
@@ -113,7 +113,7 @@ class QNetwork(nn.Module):
             nn.ReLU(),
             nn.Conv2d(64, 64, 3, stride=1),
             nn.ReLU(),
-            nn.Flatten()
+            nn.Flatten(),
         )
         self.advantage = nn.Sequential(
             nn.Linear(3136, 512),
@@ -154,7 +154,7 @@ if __name__ == "__main__":
             save_code=True,
         )
         wandb.tensorboard.patch(save=False)
-        
+
     writer = SummaryWriter(f"runs/{run_name}")
     writer.add_text(
         "hyperparameters",

--- a/vdueling_dqn_atari.py
+++ b/vdueling_dqn_atari.py
@@ -148,12 +148,13 @@ if __name__ == "__main__":
         wandb.init(
             project=args.wandb_project_name,
             entity=args.wandb_entity,
-            sync_tensorboard=True,
             config=vars(args),
             name=run_name,
             monitor_gym=True,
             save_code=True,
         )
+        wandb.tensorboard.patch(save=False)
+        
     writer = SummaryWriter(f"runs/{run_name}")
     writer.add_text(
         "hyperparameters",

--- a/vdueling_dqn_atari.py
+++ b/vdueling_dqn_atari.py
@@ -127,9 +127,9 @@ class QNetwork(nn.Module):
         )
 
     def forward(self, x):
-        features = self.network(x / 255.0)
-        value = self.value(features)
-        advantage = self.advantage(features)
+        hidden = self.network(x / 255.0)
+        value = self.value(hidden)
+        advantage = self.advantage(hidden)
         avg_advantage = torch.mean(advantage, dim=1, keepdim=True)
         return value + advantage - avg_advantage
 

--- a/vdueling_dqn_atari.py
+++ b/vdueling_dqn_atari.py
@@ -42,9 +42,9 @@ def parse_args():
         help="if toggled, cuda will be enabled by default")
     parser.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
         help="if toggled, this experiment will be tracked with Weights and Biases")
-    parser.add_argument("--wandb-project-name", type=str, default="cleanRL",
+    parser.add_argument("--wandb-project-name", type=str, default="vectorized-value-methods",
         help="the wandb's project name")
-    parser.add_argument("--wandb-entity", type=str, default=None,
+    parser.add_argument("--wandb-entity", type=str, default="vwxyzjn",
         help="the entity (team) of wandb's project")
     parser.add_argument("--capture-video", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
         help="weather to capture videos of the agent performances (check out `videos` folder)")


### PR DESCRIPTION
I saw there was a need for the dueling DQN on the "Remaining issues & research questions" section, and I figured it would be a good first contribution. I am working on getting access to more compute right now, so I just have a few comparisons. Outside of the neural network code, the rest remains the same as the DQN. 

Cartpole: Orange is dueling, green is dqn
![cartpole_comp](https://user-images.githubusercontent.com/42878312/151440927-93e2787d-70c4-48e1-908e-2dff7bd2bf82.svg)
Lunar Lander: pink is dueling, blue is dqn
![charts_episodic_return (2)](https://user-images.githubusercontent.com/42878312/151440994-bb6e7e88-7d0e-498e-9fea-f1af898af36d.svg)
Breakout: both are dueling (two separate runs)
![charts_episodic_return (3)](https://user-images.githubusercontent.com/42878312/151441078-2e8fa35b-899a-4bf4-8b2f-f5d8feb99f84.svg)

